### PR TITLE
[GITHUB-9] Add support for password

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 ---
 
-language: python
-python: "2.7"
-
+group: stable
+dist: trusty
 branches:
   only:
     - develop
     - master
+
+language: python
+python: "2.7"
+
+env:
+  - ANSIBLE_INSTALL_VERSION=1.9.4
+  - ANSIBLE_INSTALL_VERSION=2.0.0.2
 
 before_install:
   # Make sure everything's up to date.
@@ -14,7 +20,7 @@ before_install:
 
 install:
   # Install Ansible.
-  - pip install ansible==1.9.4
+  - pip install ansible==${ANSIBLE_INSTALL_VERSION}
 
 script:
   # Install Role Dependencies

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ all: test clean
 
 test: test_deps vagrant_up
 
+watch: test_deps
+	while sleep 1; do \
+		find defaults/ meta/ tasks/ tests/vagrant/test.yml \
+		| entr -d make vagrant_up; \
+	done
+
 integration_test: clean integration_test_deps vagrant_up clean
 
 test_deps:
@@ -20,18 +26,12 @@ integration_test_deps:
 	mv tests/vagrant/integration_requirements.yml.bak tests/vagrant/integration_requirements.yml
 
 vagrant_up:
-	@cd tests/vagrant; \
-	if (vagrant status | grep -E "(running|saved|poweroff)" 1>/dev/null) then \
-		vagrant up || exit 1; \
-		vagrant provision || exit 1; \
-	else \
-		vagrant up || exit 1; \
-	fi;
+	cd tests/vagrant && vagrant up --no-provision
+	cd tests/vagrant && vagrant provision
 
 vagrant_ssh:
-	@cd tests/vagrant; \
-	vagrant up || exit 1; \
-	vagrant ssh
+	cd tests/vagrant && vagrant up --no-provision
+	cd tests/vagrant && vagrant ssh
 
 clean:
 	rm -rf tests/vagrant/ansible-city.*

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -15,6 +15,7 @@
     group: "{{ item.group | default(omit) }}"
     groups: "{{ item.groups | default([ ]) | join(',') | default(omit) }}"
     name: "{{ item.name }}"
+    password: "{{ item.password | default(omit) }}"
     shell: "{{ item.shell | default('/bin/bash') }}"
     state: "{{ item.state | default(omit) }}"
   with_items: users_and_groups.users

--- a/tests/vagrant/test.yml
+++ b/tests/vagrant/test.yml
@@ -17,6 +17,7 @@
               - lorem
             ssh_key: ./lorem.ipsum.pub
           - name: dolor.ament
+            password: $6$xWEcHT7XQyoM8BcG$8PNUEIk/W0HabKwuOKdqRihwDnzDIS9mvKWzUzh2JZLG2/YJzedeFNT2o2nbXD0JqoKenebkF0lRPc/wX.NzM0
             groups:
               - ipsum
           - name: no.extra.group
@@ -26,5 +27,11 @@
       become: yes
       become_user: lorem.ipsum
       shell: cat /home/lorem.ipsum/.ssh/authorized_keys | grep 'ssh-rsa AAAAB3NzaC1yc2E'
+      tags:
+        - assert
+
+    - name: User dolor.ament has a password
+      become: yes
+      command: grep 'dolor.ament:$6$xWEcHT7XQyoM8BcG$8PNUEIk/W0HabKwuOKdqRihwDnzDIS9mvKWzUzh2JZLG2/YJzedeFNT2o2nbXD0JqoKenebkF0lRPc/wX.NzM0' /etc/shadow
       tags:
         - assert


### PR DESCRIPTION
If for some reason you can't use SSH keys and you're forced to use
passwords, you can now specify a password hash for a user.

Simply run `mkpasswd --method=SHA-512` to get the password hash.
